### PR TITLE
Fix typo in config file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const minimatch = require('minimatch')
 
-const CONFIG_FILE = 'baumfleger.yml'
+const CONFIG_FILE = 'baumpfleger.yml'
 
 const DEFAULT_CONFIG = {
   enabled: false


### PR DESCRIPTION
The config file name doesn't match the readme.